### PR TITLE
Add limitation to SMT depth. Depth should be < 255

### DIFF
--- a/contracts/Smt.metasol
+++ b/contracts/Smt.metasol
@@ -17,6 +17,7 @@ library SMT{{hashname}} {
     function initialize(MerkleTree storage tree, uint8 _depth) internal {
         require(tree.depth == 0, "Cannot initialize twice");
         require(_depth > 0, "Depth must be non-zero");
+        require(_depth < 255, "Depth must be < 255");
         tree.emptySubtreeCache[0] = {{hash}}("");
         // current depth == 0
         tree._calculateEmptySubtreeHash(_depth);
@@ -35,6 +36,7 @@ library SMT{{hashname}} {
         uint8 oldDepth = tree.depth;
         // overflow protection done by solidity 0.8
         uint8 newDepth = oldDepth + depthDifference;
+        require(newDepth < 255, "newDepth must be < 255");
 
         tree._calculateEmptySubtreeHash(newDepth);
 

--- a/contracts/Smt.metasol
+++ b/contracts/Smt.metasol
@@ -26,7 +26,7 @@ library SMT{{hashname}} {
 
     function totalElements(MerkleTree storage tree) internal view returns (uint256) {
         // 1<<depth == 2**depth
-        // max(totalElements) == 2**255
+        // max(totalElements) == 2**254
         return 1<<tree.depth;
     }
 


### PR DESCRIPTION
If newDepth == 255 here we can have infinity loop: 

```
    function increaseDepth(MerkleTree storage tree, uint8 depthDifference) internal {
        require(tree.depth > 0, "Tree must be initialized");
        require(depthDifference > 0, "depthDifference must be non-zero");
        uint8 oldDepth = tree.depth;
        // overflow protection done by solidity 0.8
        uint8 newDepth = oldDepth + depthDifference;

        tree._calculateEmptySubtreeHash(newDepth);

        for (uint8 level = oldDepth+1; level <= newDepth; level = inc(level)) {
            tree._updateNode(level, 0);
        }

        tree.depth = newDepth;
    }
```

because there is no uint8 which will be <= 255.

thanks @miladpiri