### PR TITLE
Consistent naming

### DIFF
--- a/contracts/PublicSmt.metasol
+++ b/contracts/PublicSmt.metasol
@@ -11,27 +11,27 @@ contract PublicSmt{{hashname}} {
         tree.initialize(_depth);
     }
 
-    function _increaseDepth(uint8 depthDifference) public {
+    function increaseDepth(uint8 depthDifference) public {
         tree.increaseDepth(depthDifference);
     }
 
-    function _decreaseDepth(uint8 depthDifference) public {
+    function decreaseDepth(uint8 depthDifference) public {
         tree.decreaseDepth(depthDifference);
     }
 
-    function _modifyElement(uint index, bytes calldata element) public {
+    function modifyElement(uint index, bytes calldata element) public {
         tree.modifyElement(index, element);
     }
 
-    function _addElement(uint index, bytes calldata element) public {
+    function addElement(uint index, bytes calldata element) public {
         tree.addElement(index, element);
     }
 
-    function _removeElement(uint index) public {
+    function removeElement(uint index) public {
         tree.removeElement(index);
     }
 
-    function _getRoot() public view returns (bytes32) {
+    function getRoot() public view returns (bytes32) {
         return tree.getRoot();
     }
 }

--- a/contracts/Smt.metasol
+++ b/contracts/Smt.metasol
@@ -20,7 +20,7 @@ library SMT{{hashname}} {
         require(_depth < 255, "Depth must be < 255");
         tree.emptySubtreeCache[0] = {{hash}}("");
         // current depth == 0
-        tree._calculateEmptySubtreeHash(_depth);
+        _calculateEmptySubtreeHash(tree, _depth);
         tree.depth = _depth;
     }
 
@@ -38,10 +38,10 @@ library SMT{{hashname}} {
         uint8 newDepth = oldDepth + depthDifference;
         require(newDepth < 255, "newDepth must be < 255");
 
-        tree._calculateEmptySubtreeHash(newDepth);
+        _calculateEmptySubtreeHash(tree, newDepth);
 
         for (uint8 level = oldDepth+1; level <= newDepth; level = inc(level)) {
-            tree._updateNode(level, 0);
+            _updateNode(tree, level, 0);
         }
 
         tree.depth = newDepth;
@@ -72,7 +72,7 @@ library SMT{{hashname}} {
         return tree.nodes[tree.depth][0];
     }
 
-    function _calculateEmptySubtreeHash(MerkleTree storage tree, uint8 toLevel) internal {
+    function _calculateEmptySubtreeHash(MerkleTree storage tree, uint8 toLevel) private {
         uint8 currentDepth = tree.depth;
         bytes32 prev = tree.emptySubtreeCache[currentDepth];
 
@@ -84,7 +84,7 @@ library SMT{{hashname}} {
         }
     }
 
-    function _updateNode(MerkleTree storage tree, uint8 level, uint i) internal {
+    function _updateNode(MerkleTree storage tree, uint8 level, uint i) private {
         // conditions, enforced by other methods:
         // 1 <= level <= depth
         // 0 <= i     <  2**(depth-level)
@@ -119,14 +119,14 @@ library SMT{{hashname}} {
         tree.nodes[level][i] = {{hash}}(abi.encodePacked(v0, v1));
     }
 
-    function _modifyTree(MerkleTree storage tree, uint index, bytes32 hashedElement) internal {
+    function _modifyTree(MerkleTree storage tree, uint index, bytes32 hashedElement) private {
         require(tree.depth > 0, "Tree must be initialized");
         require(index < totalElements(tree), "Index out of bounds");
         tree.nodes[0][index] = hashedElement;
         for (uint8 level = 1; level <= tree.depth; level = inc(level)) {
             // index >> level == index / 2**level
             uint currentIndex = index >> level;
-            tree._updateNode(level, currentIndex);
+            _updateNode(tree, level, currentIndex);
         }
     }
 
@@ -134,7 +134,7 @@ library SMT{{hashname}} {
         require(data.length > 0, "Element can't be empty");
         tree.elementData[index] = data;
         bytes32 hashedElement = {{hash}}(data);
-        tree._modifyTree(index, hashedElement);
+        _modifyTree(tree, index, hashedElement);
     }
 
     function addElement(MerkleTree storage tree, uint index, bytes memory data) internal {
@@ -148,7 +148,7 @@ library SMT{{hashname}} {
         // If we will use:
         // elementData[index] = "";
         // We will spend much more gas
-        tree._modifyTree(index, EMPTY_SUBTREE);
+        _modifyTree(tree, index, EMPTY_SUBTREE);
     }
 
     // because solidity 0.8 ¯\_(ツ)_/¯

--- a/scripts/gas_stats.py
+++ b/scripts/gas_stats.py
@@ -21,12 +21,12 @@ def gas_stats(hashname, depth):
 
     gas_used_add = []
     for item in range(2**depth):
-        tx = tree._addElement(item, b'apple')
+        tx = tree.addElement(item, b'apple')
         gas_used_add.append(tx.gas_used)
 
     gas_used_remove = []
     for item in range(2**depth):
-        tx = tree._removeElement(item)
+        tx = tree.removeElement(item)
         gas_used_remove.append(tx.gas_used)
 
     print_stats("--- ADD ---", gas_used_add, 2**depth)

--- a/scripts/initspt.py
+++ b/scripts/initspt.py
@@ -4,7 +4,7 @@ from brownie import PublicSmtSha, accounts
 
 def main():
     tree = PublicSmtSha.deploy(40, {"from": accounts[0]})
-    tx0 = tree._addElement(0, b"1")
-    tx1 = tree._decreaseDepth(20)
-    tx2 = tree._increaseDepth(20)
+    tx0 = tree.addElement(0, b"1")
+    tx1 = tree.decreaseDepth(20)
+    tx2 = tree.increaseDepth(20)
     print(tx1.gas_used + tx2.gas_used)

--- a/tests/test_spt.py
+++ b/tests/test_spt.py
@@ -11,7 +11,7 @@ def get_root_4(elements):
     return '0x' + root.hex()
 
 def test_setup_depth(public_spt, accounts):
-    root = public_spt._getRoot()
+    root = public_spt.getRoot()
     empty_hash = sha256(b'').digest()
     empty_root = '0x' + sha256(empty_hash * 2).hexdigest()
     assert root == empty_root
@@ -22,57 +22,57 @@ def test_empty_roots(public_spt, accounts):
     empty_hash = sha256(b'').digest()
     for i in check_size:
         empty_hash = sha256(empty_hash * 2).digest()
-        assert trees[i]._getRoot() == '0x' + empty_hash.hex()
+        assert trees[i].getRoot() == '0x' + empty_hash.hex()
 
 def test_one_element(public_spt, accounts):
 
     trees = [PublicSmtSha.deploy(2, {"from": accounts[0]}) for i in range(4)]
 
     for i in range(4):
-        trees[i]._modifyElement(i, b'apple')
+        trees[i].modifyElement(i, b'apple')
         elements = [b''] * 4
         elements[i] = b'apple'
         root = get_root_4(elements)
-        assert root == trees[i]._getRoot()
+        assert root == trees[i].getRoot()
 
 def test_step_by_step(public_spt, accounts):
     spt = PublicSmtSha.deploy(2, {"from": accounts[0]})
 
-    spt._modifyElement(0, b'apple')
-    root = spt._getRoot()
+    spt.modifyElement(0, b'apple')
+    root = spt.getRoot()
     test_result = get_root_4([b'apple', b'', b'', b''])
     assert root == test_result
 
-    spt._modifyElement(1, b'avocado')
-    root = spt._getRoot()
+    spt.modifyElement(1, b'avocado')
+    root = spt.getRoot()
     test_result = get_root_4([b'apple', b'avocado', b'', b''])
     assert root == test_result
 
-    spt._modifyElement(2, b'clock')
-    root = spt._getRoot()
+    spt.modifyElement(2, b'clock')
+    root = spt.getRoot()
     test_result = get_root_4([b'apple', b'avocado', b'clock', b''])
     assert root == test_result
 
-    spt._modifyElement(3, b'great')
-    root = spt._getRoot()
+    spt.modifyElement(3, b'great')
+    root = spt.getRoot()
     test_result = get_root_4([b'apple', b'avocado', b'clock', b'great'])
     assert root == test_result
 
 def test_remove(public_spt, accounts):
     spt = PublicSmtSha.deploy(2, {"from": accounts[0]})
 
-    spt._modifyElement(1, b'fish')
-    root = spt._getRoot()
+    spt.modifyElement(1, b'fish')
+    root = spt.getRoot()
     test_result = get_root_4([b'', b'fish', b'', b''])
     assert root == test_result
 
-    spt._modifyElement(3, b'ice')
-    root = spt._getRoot()
+    spt.modifyElement(3, b'ice')
+    root = spt.getRoot()
     test_result = get_root_4([b'', b'fish', b'', b'ice'])
     assert root == test_result
 
-    spt._removeElement(1)
-    root = spt._getRoot()
+    spt.removeElement(1)
+    root = spt.getRoot()
     test_result = get_root_4([b'', b'', b'', b'ice'])
     assert root == test_result
 
@@ -82,7 +82,7 @@ def test_remove_empty(public_spt, accounts):
     reverted = False
 
     try:
-        tx = spt._removeElement(1)
+        tx = spt.removeElement(1)
     except Exception as e:
         reverted = True
         assert "Can't remove empty element" in e.message
@@ -93,10 +93,10 @@ def test_add_existing(public_spt, accounts):
     spt = PublicSmtSha.deploy(2, {"from": accounts[0]})
     reverted = False
 
-    spt._addElement(1, b'apple')
+    spt.addElement(1, b'apple')
 
     try:
-        tx = spt._addElement(1, b'banana')
+        tx = spt.addElement(1, b'banana')
     except Exception as e:
         reverted = True
         assert "Element already exists" in e.message
@@ -108,7 +108,7 @@ def test_incorrect_index(public_spt, accounts):
     reverted = False
 
     try:
-        tx = spt._addElement(4, b'banana')
+        tx = spt.addElement(4, b'banana')
     except Exception as e:
         reverted = True
         assert "Index out of bounds" in e.message
@@ -118,10 +118,10 @@ def test_incorrect_index(public_spt, accounts):
 def test_increase_depth(public_spt, accounts):
     spt = PublicSmtSha.deploy(1, {"from": accounts[0]})
     
-    spt._addElement(0, b'apple')
-    spt._addElement(1, b'banana')
-    spt._increaseDepth(1)
-    root = spt._getRoot()
+    spt.addElement(0, b'apple')
+    spt.addElement(1, b'banana')
+    spt.increaseDepth(1)
+    root = spt.getRoot()
 
     assert root == get_root_4([b'apple', b'banana', b'', b''])
 
@@ -129,10 +129,10 @@ def test_increase_depth(public_spt, accounts):
 def test_decrease_depth(public_spt, accounts):
     spt = PublicSmtSha.deploy(3, {"from": accounts[0]})
     
-    spt._addElement(0, b'apple')
-    spt._addElement(2, b'banana')
-    spt._decreaseDepth(1)
-    root = spt._getRoot()
+    spt.addElement(0, b'apple')
+    spt.addElement(2, b'banana')
+    spt.decreaseDepth(1)
+    root = spt.getRoot()
 
     assert root == get_root_4([b'apple', b'', b'banana', b''])
 
@@ -140,13 +140,13 @@ def test_decrease_depth(public_spt, accounts):
 def test_decrease_non_empty(public_spt, accounts):
     spt = PublicSmtSha.deploy(3, {"from": accounts[0]})
 
-    tx = spt._addElement(2, b'banana')
-    tx = spt._addElement(5, b'super banana')
+    tx = spt.addElement(2, b'banana')
+    tx = spt.addElement(5, b'super banana')
 
     reverted = False
 
     try:
-        tx = spt._decreaseDepth(1)
+        tx = spt.decreaseDepth(1)
     except Exception as e:
         reverted = True
         assert "Subtree must be empty" in e.message
@@ -157,7 +157,7 @@ def test_decrease_non_empty(public_spt, accounts):
 def test_insert_and_decrease(public_spt, accounts):
 
     spt = PublicSmtSha.deploy(10, {"from": accounts[0]})
-    spt._addElement(0, b"lol")
+    spt.addElement(0, b"lol")
 
     elhash = sha256(b"lol").digest()
     empty = sha256(b"").digest()
@@ -166,8 +166,8 @@ def test_insert_and_decrease(public_spt, accounts):
         r = sha256(r + empty).digest()
         empty = sha256(empty + empty).digest()
     
-    assert spt._getRoot() == '0x' + r.hex()
+    assert spt.getRoot() == '0x' + r.hex()
     
-    spt._decreaseDepth(9)
+    spt.decreaseDepth(9)
 
-    assert spt._getRoot() == '0x' + sha256(sha256(b"lol").digest() + sha256(b"").digest()).hexdigest()
+    assert spt.getRoot() == '0x' + sha256(sha256(b"lol").digest() + sha256(b"").digest()).hexdigest()


### PR DESCRIPTION
- make _calculateEmptySubtreeHash and _updateNode and _modifyTree private (not internal)
- remove _ from every function in PublicSmt.metasol